### PR TITLE
Add dark/light theme toggle and article excerpt display

### DIFF
--- a/layout/index.pug
+++ b/layout/index.pug
@@ -8,6 +8,8 @@ block content
             if (theme.list.date)
               div.date= date(post.date, 'YYYY-MM-DD')
             a(href=config.root + post.path, target=theme.post.blank ? "_blank" : "_self")= post.title
+            if post.excerpt
+              div.excerpt= post.excerpt
             if (theme.list.wordcount)
               div.word-count= wordcount(post.content, '') +  __('word_count')
             if (theme.post.show_tags)

--- a/layout/index.pug
+++ b/layout/index.pug
@@ -10,16 +10,17 @@ block content
             a(href=config.root + post.path, target=theme.post.blank ? "_blank" : "_self")= post.title
             if post.excerpt
               div.excerpt= post.excerpt
-            if (theme.list.wordcount)
-              div.word-count= wordcount(post.content, '') +  __('word_count')
-            if (theme.post.show_tags)
-              if post.tags.length
-                ul.tags
-                  - post.tags.each(function(tag){
-                    li
-                      span #
-                      a(href= config.root + tag.path)= tag.name
-                  - });
+            div.right-info
+              if (theme.list.wordcount)
+                div.word-count= wordcount(post.content, '') +  __('word_count')
+              if (theme.post.show_tags)
+                if post.tags.length
+                  ul.tags
+                    - post.tags.each(function(tag){
+                      li
+                        span #
+                        a(href= config.root + tag.path)= tag.name
+                    - });
   if (theme.paginator)
     div(class="paginator")
       -

--- a/layout/layout.pug
+++ b/layout/layout.pug
@@ -55,6 +55,8 @@ html(lang=config.language)
                   )
                   - var href = url.startsWith('http') ? url : root + url
                   a(href=href, target=theme.header.blank ? "_blank" : "_self")= label
+              li
+                a#theme-toggle(href="#", title="切换主题") 浅色模式
     
     if body
       div!= body

--- a/layout/post.pug
+++ b/layout/post.pug
@@ -4,6 +4,8 @@ block content
     if theme.post.title_h1
       h1= page.title
       div.time= date(page.date, 'YYYY-MM-DD')
+      if page.excerpt
+        div.excerpt= page.excerpt
       if theme.post.show_tags
         if page.tags.length
           ul.tags

--- a/source/css/home.css
+++ b/source/css/home.css
@@ -25,6 +25,7 @@ body.mobile {
 .title {
     cursor: pointer;
     padding: 15px 20px;
+    position: relative;
 }
 
 .title a {
@@ -110,11 +111,22 @@ div.date {
     color: darkgray;
 }
 
+div.excerpt {
+    font-size: 85%;
+    color: #666;
+    margin-top: 5px;
+    margin-bottom: 5px;
+    line-height: 1.5;
+    padding-right: 80px;
+}
+
 div.word-count {
-    float: right;
+    position: absolute;
+    right: 20px;
+    top: 50%;
+    transform: translateY(-50%);
     color: darkgray;
     line-height: 100%;
-    min-width: 60px;
     font-size: 85%;
 }
 
@@ -124,6 +136,9 @@ div.word-count {
     } 
     ul.tags {
         display: none;
+    }
+    div.excerpt {
+        font-size: 90%;
     }
 } 
 

--- a/source/css/home.css
+++ b/source/css/home.css
@@ -194,21 +194,57 @@ div.excerpt {
     padding-right: 80px;
 }
 
+div.right-info {
+    position: absolute;
+    right: 20px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 10px;
+}
+
 div.word-count { 
-     position: absolute; 
-     right: 20px; 
-     top: 50%; 
-     transform: translateY(-50%); 
-     color: var(--text-muted); 
-     line-height: 100%; 
-     font-size: 85%; 
- }
+    color: var(--text-muted); 
+    line-height: 100%; 
+    font-size: 85%; 
+}
+
+ul.tags {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+    font-size: 85%;
+    line-height: 100%;
+}
+
+ul.tags li:not(:last-child) {
+    margin-right: 10px;
+}
+
+ul.tags li {
+    display: inline-block;
+    margin-left: 0;
+}
+
+ul.tags li span {
+    color: var(--text-muted);
+}
+
+ul.tags li a {
+    color: var(--link-color);
+    text-decoration: none;
+    transition: color 0.3s;
+}
+
+ul.tags li a:hover {
+    color: var(--link-hover-color);
+}
 
 @media screen and (max-width: 860px) { 
-    div.word-count {
-        display: none;
-    } 
-    ul.tags {
+    div.right-info {
         display: none;
     }
     div.excerpt {
@@ -439,40 +475,6 @@ div.word-count {
 
 
 
-
-ul.tags {
-    list-style-type: none;
-    padding: 0;
-    margin: 0;
-    list-style: none;
-    font-size: 85%;
-    float: right;
-    line-height: 100%;
-    margin-right: 30px;
-}
-
-ul.tags li:not(:last-child) {
-    margin-right: 10px;
-}
-
-ul.tags li {
-    display: inline-block;
-    margin-left: 0;
-}
-
-ul.tags li span {
-    color: var(--text-muted);
-}
-
-ul.tags li a {
-    color: var(--link-color);
-    text-decoration: none;
-    transition: color 0.3s;
-}
-
-ul.tags li a:hover {
-    color: var(--link-hover-color);
-}
 
 /* micro blog highlight */
 .highlight {

--- a/source/css/home.css
+++ b/source/css/home.css
@@ -1,3 +1,61 @@
+:root {
+  --bg-color: #ffffff;
+  --text-color: #333333;
+  --text-secondary: #666666;
+  --text-muted: darkgray;
+  --border-color: LightGrey;
+  --border-color-light: #ddd;
+  --border-color-medium: #c0d3eb;
+  --border-color-dark: #dfe2e5;
+  --border-color-darker: #c6cbd1;
+  --link-color: #77b3e0;
+  --link-hover-color: #559bce;
+  --link-hover-bg: LightGrey;
+  --code-bg: #f8f8f8;
+  --blockquote-bg: #f4f4f4;
+  --navbar-bg: #fff;
+  --panel-bg: #fff;
+  --panel-heading-bg: #fff;
+  --hover-bg: #eee;
+  --table-bg: #fff;
+  --table-bg-alt: #f6f8fa;
+  --micro-blog-date-bg: #f1f8ff;
+  --micro-blog-line-bg: #e1e4e8;
+  --highlight-border: #ff9800;
+  --highlight-shadow: rgba(255, 152, 0, 0.7);
+  --loading-bg: #ffffff;
+  --img-shadow: #555;
+}
+
+[data-theme="dark"] {
+  --bg-color: #1a1a1a;
+  --text-color: #e0e0e0;
+  --text-secondary: #b0b0b0;
+  --text-muted: #888888;
+  --border-color: #3a3a3a;
+  --border-color-light: #4a4a4a;
+  --border-color-medium: #4a5568;
+  --border-color-dark: #4a5568;
+  --border-color-darker: #4a5568;
+  --link-color: #64b5f6;
+  --link-hover-color: #90caf9;
+  --link-hover-bg: #3a3a3a;
+  --code-bg: #2d2d2d;
+  --blockquote-bg: #2d2d2d;
+  --navbar-bg: #2d2d2d;
+  --panel-bg: #2d2d2d;
+  --panel-heading-bg: #2d2d2d;
+  --hover-bg: #3a3a3a;
+  --table-bg: #2d2d2d;
+  --table-bg-alt: #252525;
+  --micro-blog-date-bg: #2a2a3a;
+  --micro-blog-line-bg: #3a3a4a;
+  --highlight-border: #ffb74d;
+  --highlight-shadow: rgba(255, 183, 77, 0.7);
+  --loading-bg: #2d2d2d;
+  --img-shadow: #000000;
+}
+
 * {
     box-sizing: border-box;
 }
@@ -11,6 +69,9 @@ table {
 body {
     font-family: STFangSong, Helvetica, Arial, Vernada, Tahoma, STXihei, "Microsoft YaHei", "Songti SC", SimSun, Heiti, sans-serif;
     font-size: 21px;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    transition: background-color 0.3s, color 0.3s, border-color 0.3s;
 }
 
 body.mobile {
@@ -20,6 +81,15 @@ body.mobile {
 .navbar-brand {
     font-family: "Palatino Linotype", "Book Antiqua", Palatino, Helvetica, STKaiti, SimSun, serif;
     font-size: 100%;
+}
+
+.navbar-nav > li > a,
+.navbar-brand {
+    text-shadow: none;
+}
+
+[data-theme="dark"] .navbar-nav > li > a:hover {
+    color: #fff;
 }
 
 .title {
@@ -32,25 +102,29 @@ body.mobile {
 }
 
 li.title:hover {
-    background-color: #eee;
+    background-color: var(--hover-bg);
 }
 
 .panel {
     border-radius: 0;
     font-size: 100%;
+    background-color: var(--panel-bg);
+    transition: background-color 0.3s;
 }
 
 .panel-default > .panel-heading {
     background-image: none;
-    background-color: #fff;
+    background-color: var(--panel-heading-bg);
     font-size: 100%;
+    transition: background-color 0.3s;
 }
 
 .navbar-default {
     background-image: none;
-    background-color: #fff;
+    background-color: var(--navbar-bg);
     box-shadow: none;
     font-size: 100%;
+    transition: background-color 0.3s;
 }
 
 .navbar-brand, .navbar-nav {
@@ -107,12 +181,12 @@ div.outer {
 
 div.date {
     font-size: 80%;
-    color: darkgray;
+    color: var(--text-muted);
 }
 
 div.word-count {
     float: right;
-    color: darkgray;
+    color: var(--text-muted);
     line-height: 100%;
     min-width: 60px;
     font-size: 85%;
@@ -135,14 +209,17 @@ div.word-count {
 
 .paginator .page-number,
 .paginator .extend {
-    border: 1px solid #ddd;
+    border: 1px solid var(--border-color-light);
     cursor: pointer;
     padding: 15px 20px;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    transition: background-color 0.3s, color 0.3s, border-color 0.3s;
 }
 
 .paginator .page-number:hover,
 .paginator .extend:hover {
-    background-color: #eee;
+    background-color: var(--hover-bg);
     font-size: 100%;
 }
 
@@ -200,7 +277,8 @@ div.word-count {
   height: 200px;
   display: inline-block;
   overflow: hidden;
-  background: #ffffff;
+  background: var(--loading-bg);
+  transition: background 0.3s;
 }
 .ldio-fwkeq5l2tj8 {
   width: 100%;
@@ -244,10 +322,11 @@ div.word-count {
 
 .micro-blog blockquote {
     padding: 0 1em;
-    color: #6a737d;
-    border-left: .25em solid #dfe2e5;
+    color: var(--text-secondary);
+    border-left: .25em solid var(--border-color-dark);
     margin-block-start: 1em;
     margin-block-end: 1em;
+    transition: color 0.3s, border-color 0.3s;
 }
 
 .mobile .micro-blog blockquote {
@@ -264,9 +343,11 @@ div.word-count {
 
 .micro-blog .list-group-item {
     margin-bottom: 40px;
-    border: 1px solid #c0d3eb;
+    border: 1px solid var(--border-color-medium);
     padding: 0px;
     border-radius: 6px;
+    background-color: var(--bg-color);
+    transition: background-color 0.3s, border-color 0.3s;
 }
 
 .micro-blog .list-group-item:after {
@@ -277,19 +358,21 @@ div.word-count {
     display: block;
     width: 2px;
     content: "";
-    background-color: #e1e4e8;
+    background-color: var(--micro-blog-line-bg);
     z-index: -1;
+    transition: background-color 0.3s;
 }
 
 .micro-blog .list-group-item .date {
     font-size: 90%;
-    background-color: #f1f8ff;
-    border-bottom: 1px solid #c0d3eb;
-    color: #000;
+    background-color: var(--micro-blog-date-bg);
+    border-bottom: 1px solid var(--border-color-medium);
+    color: var(--text-color);
     padding: 5px 20px;
     border-top-left-radius: 6px;
     border-top-right-radius: 6px;
     position: relative;
+    transition: background-color 0.3s, border-color 0.3s, color 0.3s;
 }
 
 .micro-blog .list-group-item .date a {
@@ -303,9 +386,9 @@ div.word-count {
 
 .mobile .micro-blog .list-group-item .date {
     font-size: 90%;
-    background-color: #f1f8ff;
-    border-bottom: 1px solid #c0d3eb;
-    color: #000;
+    background-color: var(--micro-blog-date-bg);
+    border-bottom: 1px solid var(--border-color-medium);
+    color: var(--text-color);
     padding: 10px 25px;
     border-top-left-radius: 6px;
     border-top-right-radius: 6px;
@@ -317,16 +400,18 @@ div.word-count {
 
 /* table style */
 .micro-blog table tr {
-    background-color: #fff;
-    border-top: 1px solid #c6cbd1;
+    background-color: var(--table-bg);
+    border-top: 1px solid var(--border-color-darker);
+    transition: background-color 0.3s;
 }
 .micro-blog table tr:nth-child(2n) {
-    background-color: #f6f8fa;
+    background-color: var(--table-bg-alt);
 }
 .micro-blog table td,
 .micro-blog table th {
     padding: 6px 13px;
-    border: 1px solid #dfe2e5;
+    border: 1px solid var(--border-color-dark);
+    transition: border-color 0.3s;
 }
 
 /* tabs */
@@ -361,25 +446,40 @@ ul.tags li {
 }
 
 ul.tags li span {
-    color: darkgray;
+    color: var(--text-muted);
 }
 
 ul.tags li a {
-    color: #77b3e0;
+    color: var(--link-color);
     text-decoration: none;
+    transition: color 0.3s;
 }
 
 ul.tags li a:hover {
-    color: #559bce;
+    color: var(--link-hover-color);
 }
 
 /* micro blog highlight */
 .highlight {
-    border: 2px solid #ff9800;
-    box-shadow: 0 0 10px rgba(255, 152, 0, 0.7);
+    border: 2px solid var(--highlight-border);
+    box-shadow: 0 0 10px var(--highlight-shadow);
     transition: all 0.5s ease;
 }
 
 .list-group-item {
     transition: all 0.5s ease;
+}
+
+/* dark mode specific overrides */
+[data-theme="dark"] .micro-blog blockquote {
+    color: var(--text-secondary);
+    border-left-color: var(--border-color-dark);
+}
+
+[data-theme="dark"] .list-group-item {
+    background-color: var(--navbar-bg);
+}
+
+[data-theme="dark"] img {
+    box-shadow: 0 0 10px var(--img-shadow);
 }

--- a/source/css/post.css
+++ b/source/css/post.css
@@ -76,10 +76,12 @@ line-height: 1.8;
 
 H1 {
   font-family: "Palatino Linotype", "Book Antiqua", Palatino, Helvetica, STKaiti, SimSun, serif;
-  line-height: 1.0;
+  line-height: 1.3;
   color: var(--text-secondary);
   text-align: center;
   font-size: 1.8em;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
   transition: color 0.3s;
 }
 

--- a/source/css/post.css
+++ b/source/css/post.css
@@ -1,3 +1,49 @@
+:root {
+  --bg-color: #ffffff;
+  --text-color: #333333;
+  --text-secondary: #666666;
+  --text-muted: #808080;
+  --border-color: LightGrey;
+  --border-color-dark: #dfe2e5;
+  --border-color-darker: #c6cbd1;
+  --link-color: #930ee4;
+  --link-hover-bg: LightGrey;
+  --code-bg: #f8f8f8;
+  --code-border: #E0E0E0;
+  --blockquote-bg: #f4f4f4;
+  --table-bg: #fff;
+  --table-bg-alt: #f6f8fa;
+  --card-bg: #f4f4f4;
+  --card-content-bg: #fff;
+  --img-shadow: #555;
+  --notice-color: #AA4433;
+  --sd-color: #0006;
+  --sd-hover-color: #000f;
+}
+
+[data-theme="dark"] {
+  --bg-color: #1a1a1a;
+  --text-color: #e0e0e0;
+  --text-secondary: #b0b0b0;
+  --text-muted: #888888;
+  --border-color: #3a3a3a;
+  --border-color-dark: #4a5568;
+  --border-color-darker: #4a5568;
+  --link-color: #bb86fc;
+  --link-hover-bg: #3a3a3a;
+  --code-bg: #2d2d2d;
+  --code-border: #4a4a4a;
+  --blockquote-bg: #2d2d2d;
+  --table-bg: #2d2d2d;
+  --table-bg-alt: #252525;
+  --card-bg: #2d2d2d;
+  --card-content-bg: #2d2d2d;
+  --img-shadow: #000000;
+  --notice-color: #ff6b6b;
+  --sd-color: rgba(255, 255, 255, 0.4);
+  --sd-hover-color: rgba(255, 255, 255, 0.9);
+}
+
 * {
   box-sizing: border-box;
 }
@@ -15,6 +61,9 @@ table {
 body {
   font-family:"lucida grande", "lucida sans unicode", lucida, helvetica, "Hiragino Sans GB", "Microsoft YaHei", "WenQuanYi Micro Hei", sans-serif;
   font-size: 18px;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  transition: background-color 0.3s, color 0.3s, border-color 0.3s;
 }
 
 body.mobile {
@@ -28,39 +77,43 @@ line-height: 1.8;
 H1 {
   font-family: "Palatino Linotype", "Book Antiqua", Palatino, Helvetica, STKaiti, SimSun, serif;
   line-height: 1.0;
-  color: #666666;
+  color: var(--text-secondary);
   text-align: center;
   font-size: 1.8em;
+  transition: color 0.3s;
 }
 
 H2 {
   font-family: "Palatino Linotype", "Book Antiqua", Palatino, Helvetica, STKaiti, SimSun, serif;
   margin-bottom: 40px;
   padding: 5px;
-  border-bottom: 2px LightGrey solid;
+  border-bottom: 2px var(--border-color) solid;
   width: 98%;
   line-height: 150%;
-  color: #666666;
+  color: var(--text-secondary);
+  transition: color 0.3s, border-color 0.3s;
 }
 
 H3 {
   font-family: "Palatino Linotype", "Book Antiqua", Palatino, Helvetica, STKaiti, SimSun, serif;
   margin-top: 40px;
   margin-bottom: 30px;
-  border-bottom: 1px LightGrey solid;
+  border-bottom: 1px var(--border-color) solid;
   width: 98%;
   line-height: 150%;
-  color: #666666;
+  color: var(--text-secondary);
+  transition: color 0.3s, border-color 0.3s;
 }
 
 H4 {
   font-family: "Palatino Linotype", "Book Antiqua", Palatino, Helvetica, STKaiti, SimSun, serif;
   margin-top: 40px;
   margin-bottom: 30px;
-  border-bottom: 1px LightGrey solid;
+  border-bottom: 1px var(--border-color) solid;
   width: 98%;
   line-height: 150%;
-  color: #666666;
+  color: var(--text-secondary);
+  transition: color 0.3s, border-color 0.3s;
 }
 
 .time {
@@ -72,7 +125,9 @@ H4 {
 
 .box {
   padding: 2% 8% 5% 8%;
-  border: 1px solid LightGrey;
+  border: 1px solid var(--border-color);
+  background-color: var(--bg-color);
+  transition: border-color 0.3s, background-color 0.3s;
 }
 
 
@@ -82,13 +137,14 @@ li {
 
 
 blockquote {
-  border-left: 5px lightgrey solid;
+  border-left: 5px var(--border-color) solid;
   padding-left: 15px;
   margin-left: 20px;
-  background: #f4f4f4;
+  background: var(--blockquote-bg);
   padding-top: 1px;
   padding-bottom: 1px;
   font-size: 90%;
+  transition: border-color 0.3s, background-color 0.3s;
 }
 
 blockquote p {
@@ -103,57 +159,63 @@ blockquote li p {
 pre {
   font-family: Inconsolata, Consolas, "DEJA VU SANS MONO", "DROID SANS MONO", Proggy, monospace;
   font-size: 90%;
-  background-color: #f8f8f8;
-  border: 1px solid #E0E0E0;
+  background-color: var(--code-bg);
+  border: 1px solid var(--code-border);
   border-radius: 4px;
   padding: 5px;
   line-height: 1.3;
+  transition: background-color 0.3s, border-color 0.3s;
 }
 
 .hljs {
-  background-color: #f8f8f8;
+  background-color: var(--code-bg);
+  transition: background-color 0.3s;
 }
 
 p code{
   font-size: 90%;
-  background-color: #f4f4f4;
-  border: 1px solid #E0E0E0;
+  background-color: var(--blockquote-bg);
+  border: 1px solid var(--code-border);
   border-radius: 2px;
   padding: 0 3px;
   margin: 0 3px;
+  transition: background-color 0.3s, border-color 0.3s;
 }
 
 li code{
   font-size: 90%;
-  background-color: #f4f4f4;
-  border: 1px solid #E0E0E0;
+  background-color: var(--blockquote-bg);
+  border: 1px solid var(--code-border);
   border-radius: 2px;
   padding: 0 3px;
   margin: 0 3px;
+  transition: background-color 0.3s, border-color 0.3s;
 }
 
 a {
   text-decoration: none;
   cursor: crosshair;
   border-bottom: 1px dashed orange;
-  color: #930ee4;
+  color: var(--link-color);
+  transition: color 0.3s, background-color 0.3s;
 }
 
 a:hover {
-  background-color: LightGrey;
+  background-color: var(--link-hover-bg);
 }
 
 
 img {
   display: block;
-  box-shadow: 0 0 10px #555;
+  box-shadow: 0 0 10px var(--img-shadow);
   border-radius: 6px;
   margin-left: auto;
   margin-right: auto;
   margin-top: 10px;
   margin-bottom: 10px;
-  -webkit-box-shadow: 0 0 10px #555;
+  -webkit-box-shadow: 0 0 10px var(--img-shadow);
   max-width: 100%;
+  transition: box-shadow 0.3s;
 }
 
 img.displayed {
@@ -186,11 +248,11 @@ video {
 }
 
 hr {
-  color: LightGrey;
+  color: var(--border-color);
 }
 
 p.notice {
-  color: #AA4433;
+  color: var(--notice-color);
   font-size: 14px;
 }
 
@@ -205,13 +267,17 @@ body.mobile div.outer {
 div.inner {
   margin: 0% 14%;
   padding: 2% 8% 4% 8%;
-  border: 1px solid LightGrey;
+  border: 1px solid var(--border-color);
+  background-color: var(--bg-color);
+  transition: border-color 0.3s, background-color 0.3s;
 }
 
 div.inner-narrow {
   margin: 0% 7%;
   padding: 2% 8% 4% 8%;
-  border: 1px solid LightGrey;
+  border: 1px solid var(--border-color);
+  background-color: var(--bg-color);
+  transition: border-color 0.3s, background-color 0.3s;
 }
 
 body.mobile div.inner {
@@ -268,7 +334,7 @@ body.mobile div.ad-banner {
 
 /* image no shadow */
 .no-shadow {
-  box-shadow: 0 0 0px #fff;
+  box-shadow: 0 0 0px var(--bg-color);
 }
 
 /* custom modal style */
@@ -303,23 +369,26 @@ table {
   border-collapse: collapse;
 }
 table tr {
-  background-color: #fff;
-  border-top: 1px solid #c6cbd1;
+  background-color: var(--table-bg);
+  border-top: 1px solid var(--border-color-darker);
+  transition: background-color 0.3s;
 }
 table th, table td {
   padding: 6px 13px;
-  border: 1px solid #dfe2e5;
+  border: 1px solid var(--border-color-dark);
+  transition: border-color 0.3s;
 }
 /* table tr:nth-child(2n) {
-  background-color: #f6f8fa;
+  background-color: var(--table-bg-alt);
 } */
 
 /****** weibo card ******/
 .cards {
-  background: #f4f4f4;
+  background: var(--card-bg);
   padding: 15px;
   padding-left: 30px;
   border-radius: 10px;
+  transition: background-color 0.3s;
 }
 .card {
   display: flex;
@@ -328,16 +397,18 @@ table th, table td {
   display: flex;
   align-items: flex-start;
   margin-top: 15px;
-  color: #808080;
+  color: var(--text-muted);
   font-style: oblique;
   flex-basis: 80px;
+  transition: color 0.3s;
 }
 .card-content {
   padding: 0 20px;
   margin: 15px;
-  background: #fff;
+  background: var(--card-content-bg);
   border-radius: 10px;
   flex-basis: 90%;
+  transition: background-color 0.3s;
 }
 
 @media screen and (max-width: 860px) { 
@@ -349,7 +420,7 @@ table th, table td {
   .card-time {
     display: flex;
     align-items: flex-end;
-    color: #808080;
+    color: var(--text-muted);
     font-style: oblique;
   }
   .card-time>p {
@@ -361,7 +432,7 @@ table th, table td {
   .card-content {
     padding: 0 30px;
     margin: 15px 0px;
-    background: #fff;
+    background: var(--card-content-bg);
     border-radius: 10px;
     max-width: 97%;
   }
@@ -373,31 +444,34 @@ table th, table td {
 /* subtitle description */
 sd {
   font-size: 75%;
-  color: #0006;
+  color: var(--sd-color);
+  transition: color 0.3s;
 }
 sd:hover {
-  color: #000f;
+  color: var(--sd-hover-color);
 }
 
 sdr {
   font-size: 75%;
-  color: #0006;
+  color: var(--sd-color);
   line-height: 1.8;
   float: right;
   margin-left: 15px;
+  transition: color 0.3s;
 }
 sdr:hover {
-  color: #000f;
+  color: var(--sd-hover-color);
 }
 
 sd-time {
   font-size: 75%;
   display: block;
   line-height: 3;
-  color: #0006;
+  color: var(--sd-color);
+  transition: color 0.3s;
 }
 sd-time:hover {
-  color: #000f;
+  color: var(--sd-hover-color);
 }
 
 .textAlignRight {
@@ -464,4 +538,25 @@ ul.tags li:not(:last-child) {
 
 div.title-margin {
   margin-bottom: 40px;
+}
+
+/* dark mode specific overrides */
+[data-theme="dark"] .box,
+[data-theme="dark"] div.inner,
+[data-theme="dark"] div.inner-narrow {
+  border-color: var(--border-color);
+}
+
+[data-theme="dark"] blockquote {
+  color: var(--text-secondary);
+}
+
+[data-theme="dark"] pre,
+[data-theme="dark"] code {
+  color: var(--text-color);
+}
+
+[data-theme="dark"] table th,
+[data-theme="dark"] table td {
+  border-color: var(--border-color-dark);
 }

--- a/source/css/post.css
+++ b/source/css/post.css
@@ -70,6 +70,15 @@ H4 {
   margin-bottom: 20px;
 }
 
+.excerpt {
+  text-align: center;
+  font-size: 85%;
+  color: #666;
+  margin-bottom: 30px;
+  line-height: 1.6;
+  font-style: italic;
+}
+
 .box {
   padding: 2% 8% 5% 8%;
   border: 1px solid LightGrey;

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -11,8 +11,68 @@ function getUrlRelativePath() {
   return relUrl;
 }
 
+const ThemeManager = {
+  THEME_KEY: 'theme',
+
+  getSavedTheme() {
+    return localStorage.getItem(this.THEME_KEY);
+  },
+
+  saveTheme(theme) {
+    localStorage.setItem(this.THEME_KEY, theme);
+  },
+
+  getSystemTheme() {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  },
+
+  applyTheme(theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+    this.updateToggleButtonIcon(theme);
+  },
+
+  updateToggleButtonIcon(theme) {
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (!toggleBtn) return;
+
+    toggleBtn.textContent = theme === 'dark' ? '深色模式' : '浅色模式';
+  },
+
+  toggleTheme() {
+    const currentTheme = document.documentElement.getAttribute('data-theme') || 'light';
+    const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+    this.applyTheme(newTheme);
+    this.saveTheme(newTheme);
+  },
+
+  init() {
+    const savedTheme = this.getSavedTheme();
+    const systemTheme = this.getSystemTheme();
+    const theme = savedTheme || systemTheme;
+    this.applyTheme(theme);
+
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        this.toggleTheme();
+      });
+    }
+
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+      if (!this.getSavedTheme()) {
+        this.applyTheme(e.matches ? 'dark' : 'light');
+      }
+    });
+  }
+};
+
 $(() => {
   document.querySelectorAll("pre code").forEach((block) => {
     hljs.highlightBlock(block);
   });
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+  ThemeManager.init();
 });


### PR DESCRIPTION
Fixed overlapping elements on the right side of the article list (primarily the word count and tags), fixedlong H1 headings not wrapping to new lines, and adjusted element spacing.

修复了文章列表右侧元素重叠（主要是那个word-count和tags），修复长标题就是H1的长标题不换行，调整元素间距。